### PR TITLE
MacroModel fix

### DIFF
--- a/stko/optimizers/macromodel.py
+++ b/stko/optimizers/macromodel.py
@@ -809,10 +809,10 @@ class MacroModelForceField(MacroModel):
                 and
                 bond.get_atom2().get_id() in bonder_ids
             ):
-                atom1_id = bond.get_atom1().get_id()
-                atom2_id = bond.get_atoms2().get_id()
                 continue
 
+            atom1_id = bond.get_atom1().get_id()
+            atom2_id = bond.get_atom2().get_id()
             # Make sure that the indices are increased by 1 in the .mae
             # file.
             atom1_id += 1
@@ -1263,6 +1263,7 @@ class MacroModelMD(MacroModel):
             rdkit_opt_mol.GetConformer().GetPositions()
         )
         move_generated_macromodel_files(run_name, output_dir)
+        return mol
 
     def _fix_distances(self, mol, fix_block):
         """

--- a/stko/utilities/utilities.py
+++ b/stko/utilities/utilities.py
@@ -11,6 +11,7 @@ from rdkit.Geometry import Point3D
 import numpy as np
 import time
 from contextlib import contextmanager
+import shutil
 import os
 import subprocess as sp
 import gzip
@@ -738,7 +739,7 @@ def move_generated_macromodel_files(basename, output_dir):
         # Do not move the output_dir.
         if filename == output_dir:
             continue
-        os.rename(filename, f'{output_dir}/{filename}')
+        shutil.move(filename, f'{output_dir}/{filename}')
 
 
 def normalize_vector(vector):


### PR DESCRIPTION
Added return to MacroModelMD optimise function and fixed restricted optimisations, where bonds created during stk build were not optimised.