### PR TITLE
New rdkit metal optimizer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="stko",
-    version="0.0.33",
+    version="0.0.34",
     author="Steven Bennett, Andrew Tarzia",
     author_email="s.bennett18@imperial.ac.uk",
     description=(

--- a/stko/optimizers/rdkit.py
+++ b/stko/optimizers/rdkit.py
@@ -303,19 +303,10 @@ class MetalOptimizer(Optimizer):
         Parameters
         ----------
         metal_binder_distance : :class:`float`
-            Distance in Angstrom [fillin]
+            Distance in Angstrom.
 
         metal_binder_forceconstant : :class:`float`
             Force constant to use for restricted metal-ligand bonds.
-            In XX.
-
-        binder_ligand_forceconstant : :class:`float`
-            Force constant to use for restricted metal-ligand bonds.
-            In XX. [Fill in]
-
-        relative_distance : :class:``
-            Set the relative distance to optimise the metal-ligand
-            bonds to.
 
         max_iterations : :class:`int`, optional
             Number of iteractions to run.
@@ -336,11 +327,11 @@ class MetalOptimizer(Optimizer):
 
         Parameters
         ----------
-        ff : :class:`rdkit.ForceField`
-            Forcefield to apply constraints to. Generally use UFF.
-
         mol : :class:`.Molecule`
             The molecule to be optimized.
+
+        ff : :class:`rdkit.ForceField`
+            Forcefield to apply constraints to. Generally use UFF.
 
         metal_bonds : :class:`.list` of :class:`stk.Bond`
             List of bonds including metal atoms.

--- a/stko/optimizers/rdkit.py
+++ b/stko/optimizers/rdkit.py
@@ -5,6 +5,7 @@ RDKit Optimizers
 #. :class:`.MMFF`
 #. :class:`.UFF`
 #. :class:`.ETKDG`
+#. :class:`.MetalOptimizer`
 
 Wrappers for optimizers within the :mod:`rdkit` code.
 
@@ -29,9 +30,17 @@ Wrappers for optimizers within the :mod:`rdkit` code.
 """
 
 import logging
+import numpy as np
 import rdkit.Chem.AllChem as rdkit
+from itertools import combinations
 
 from .optimizers import Optimizer
+from ..utilities import (
+    get_metal_atoms,
+    get_metal_bonds,
+    to_rdkit_mol_without_metals,
+    vector_angle,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -199,5 +208,263 @@ class ETKDG(Optimizer):
         mol = mol.with_position_matrix(
             position_matrix=rdkit_mol.GetConformer().GetPositions()
         )
+
+        return mol
+
+
+class MetalOptimizer(Optimizer):
+    """
+    Applies forcefield optimizers that can handle metal centres.
+
+    Notes
+    -----
+    By default, :meth:`optimize` will run a restricted optimization
+    using constraints and the UFF. To implement this, metal atoms are
+    replaced by noninteracting H atoms, and constraints are applied
+    to maintain the metal centre geometry.
+    Restrictions are applied to the ligand with respect to its input
+    structure. So if that is poorly optimised, then the output will be
+    also.
+
+    Examples
+    --------
+    :class:`MetalOptimizer` allows for the restricted optimization of
+    :class:`ConstructedMolecule` instances containing metals. Note that
+    this optimizer algorithm is not very robust to large bonds and may
+    fail.
+
+    .. code-block:: python
+        import stk
+        import stko
+
+        # Produce a Pd+2 atom with 4 functional groups.
+        palladium_atom = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0., 0., 0.]],
+        )
+
+        # Build a building block with two functional groups using
+        # the SmartsFunctionalGroupFactory.
+        bb1 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage1 = stk.ConstructedMolecule(
+            stk.cage.M3L6(
+                building_blocks=(palladium_atom, bb1),
+                # Ensure that bonds between the GenericFunctionalGroups
+                # of the ligand and the SingleAtom functional groups
+                # of the metal are dative.
+                reaction_factory=stk.DativeReactionFactory(
+                    stk.GenericReactionFactory(
+                        bond_orders={
+                            frozenset({
+                                stk.GenericFunctionalGroup,
+                                stk.SingleAtom
+                            }): 9
+                        }
+                    )
+                ),
+                optimizer=stk.MCHammer(),
+            )
+        )
+
+        # Define an optimizer.
+        optimizer = stko.MetalOptimizer()
+
+        # Optimize.
+        cage1 = optimizer.optimize(mol=cage1)
+
+    """
+
+    def __init__(
+        self,
+        metal_binder_distance=1.6,
+        metal_binder_forceconstant=1.0e2,
+        max_iterations=500,
+    ):
+        """
+        Initialize a :class:`MetalOptimizer` instance.
+
+        Parameters
+        ----------
+        metal_binder_distance : :class:`float`
+            Distance in Angstrom [fillin]
+
+        metal_binder_forceconstant : :class:`float`
+            Force constant to use for restricted metal-ligand bonds.
+            In XX.
+
+        binder_ligand_forceconstant : :class:`float`
+            Force constant to use for restricted metal-ligand bonds.
+            In XX. [Fill in]
+
+        relative_distance : :class:``
+            Set the relative distance to optimise the metal-ligand
+            bonds to.
+
+        max_iterations : :class:`int`, optional
+            Number of iteractions to run.
+
+        """
+        self._metal_binder_distance = metal_binder_distance
+        self._metal_binder_forceconstant = metal_binder_forceconstant
+        self._max_iterations = max_iterations
+
+    def _apply_metal_centre_constraints(
+        self,
+        mol,
+        ff,
+        metal_bonds,
+    ):
+        """
+        Applies UFF metal centre constraints.
+
+        Parameters
+        ----------
+        ff : :class:`rdkit.ForceField`
+            Forcefield to apply constraints to. Generally use UFF.
+
+        mol : :class:`.Molecule`
+            The molecule to be optimized.
+
+        metal_bonds : :class:`.list` of :class:`stk.Bond`
+            List of bonds including metal atoms.
+
+        Returns
+        -------
+        None : :class:`NoneType`
+
+        """
+
+        # Add constraints to UFF to hold metal geometry in place.
+        for bond in metal_bonds:
+            idx1 = bond.get_atom1().get_id()
+            idx2 = bond.get_atom2().get_id()
+            # Add distance constraints in place of metal bonds.
+            # Target distance set to a given metal_binder_distance.
+            ff.UFFAddDistanceConstraint(
+                idx1=idx1,
+                idx2=idx2,
+                relative=False,
+                minLen=self._metal_binder_distance,
+                maxLen=self._metal_binder_distance,
+                forceConstant=self._metal_binder_forceconstant
+            )
+
+        # Also implement angular constraints to all atoms in the
+        # metal complex.
+        for bonds in combinations(metal_bonds, r=2):
+            bond1, bond2 = bonds
+            bond1_atoms = [bond1.get_atom1(), bond1.get_atom2()]
+            bond2_atoms = [bond2.get_atom1(), bond2.get_atom2()]
+            pres_atoms = list(set(bond1_atoms + bond2_atoms))
+            # If there are more than 3 atoms, implies two
+            # independant bonds.
+            if len(pres_atoms) > 3:
+                continue
+            for atom in pres_atoms:
+                if atom in bond1_atoms and atom in bond2_atoms:
+                    idx2 = atom.get_id()
+                elif atom in bond1_atoms:
+                    idx1 = atom.get_id()
+                elif atom in bond2_atoms:
+                    idx3 = atom.get_id()
+            pos1 = [
+                i for i in mol.get_atomic_positions(atom_ids=[idx1])
+            ][0]
+            pos2 = [
+                i for i in mol.get_atomic_positions(atom_ids=[idx2])
+            ][0]
+            pos3 = [
+                i for i in mol.get_atomic_positions(atom_ids=[idx3])
+            ][0]
+            v1 = pos1 - pos2
+            v2 = pos3 - pos2
+            angle = vector_angle(v1, v2)
+            ff.UFFAddAngleConstraint(
+                idx1=idx1,
+                idx2=idx2,
+                idx3=idx3,
+                relative=False,
+                minAngleDeg=np.degrees(angle),
+                maxAngleDeg=np.degrees(angle),
+                forceConstant=1.0e5
+            )
+
+    def optimize(self, mol):
+        """
+        Optimize `mol`.
+
+        Parameters
+        ----------
+        mol : :class:`.Molecule`
+            The molecule to be optimized.
+
+        Returns
+        -------
+        mol : :class:`.Molecule`
+            The optimized molecule.
+
+        """
+        # Find all metal atoms and atoms they are bonded to.
+        metal_atoms = get_metal_atoms(mol)
+        metal_bonds, ids_to_metals = get_metal_bonds(
+            mol=mol,
+            metal_atoms=metal_atoms
+        )
+
+        # Perform a forcefield optimisation that
+        # only optimises non metal atoms that are not bonded to the
+        # metal.
+
+        # Write rdkit molecule with metal atoms and bonds deleted.
+        edit_mol = to_rdkit_mol_without_metals(
+            mol=mol,
+            metal_atoms=metal_atoms,
+            metal_bonds=metal_bonds
+        )
+
+        # Non-bonded interactions need to be explicitly turned on (if
+        # desired) because at the point of initialisation, the
+        # molecules are technically separate (not bonded) and are
+        # treated as fragments.
+        rdkit.SanitizeMol(edit_mol)
+        ff = rdkit.UFFGetMoleculeForceField(
+            edit_mol,
+            ignoreInterfragInteractions=False,
+        )
+
+        # Constrain the metal centre.
+        self._apply_metal_centre_constraints(
+            mol=mol,
+            ff=ff,
+            metal_bonds=metal_bonds,
+        )
+
+        # Optimisation with UFF in RDKit. This method uses constraints
+        # on the metal centre to attempt to enforce the metal geometry
+        # described by the metal topology.
+        ff.Minimize(maxIts=self._max_iterations)
+
+        # Update stk molecule from optimized molecule. This should
+        # only modify atom positions, which means metal atoms will be
+        # reinstated.
+        new_position_matrix = edit_mol.GetConformer().GetPositions()
+        mol = mol.with_position_matrix(new_position_matrix)
 
         return mol

--- a/stko/utilities/utilities.py
+++ b/stko/utilities/utilities.py
@@ -1103,3 +1103,33 @@ def calculate_dihedral(pt1, pt2, pt3, pt4):
     x = np.dot(v, w)
     y = np.dot(np.cross(b1, v), w)
     return np.degrees(np.arctan2(y, x))
+
+
+def vector_angle(vector1, vector2):
+    """
+    Returns the angle between two vectors in radians.
+    Parameters
+    ----------
+    vector1 : :class:`numpy.ndarray`
+        The first vector.
+    vector2 : :class:`numpy.ndarray`
+        The second vector.
+    Returns
+    -------
+    :class:`float`
+        The angle between `vector1` and `vector2` in radians.
+    """
+
+    if np.all(np.equal(vector1, vector2)):
+        return 0.
+
+    numerator = np.dot(vector1, vector2)
+    denominator = np.linalg.norm(vector1) * np.linalg.norm(vector2)
+    # This if statement prevents returns of NaN due to floating point
+    # inaccuracy.
+    term = numerator/denominator
+    if term >= 1.:
+        return 0.0
+    if term <= -1.:
+        return np.pi
+    return np.arccos(term)


### PR DESCRIPTION
Reimplements a simplified optimizer that uses RDKIT UFF implementation and treats metal atoms as dummy atoms with bond and angle constrains.