### PR TITLE
Handle changes in xtb solvent API.

### DIFF
--- a/stko/optimizers/xtb.py
+++ b/stko/optimizers/xtb.py
@@ -182,6 +182,7 @@ class XTB(Optimizer):
         calculate_hessian=True,
         num_cores=1,
         electronic_temperature=300,
+        solvent_model='gbsa',
         solvent=None,
         solvent_grid='normal',
         charge=0,
@@ -232,6 +233,13 @@ class XTB(Optimizer):
         electronic_temperature : :class:`int`, optional
             Electronic temperature in Kelvin.
 
+        solvent_model : :class:`str`
+            Solvent model to use out of older `gbsa` and newer `alpb`.
+            `gbsa` is default for backwards compatability, but `alpb`
+            is recommended.
+            For details see
+            https://xtb-docs.readthedocs.io/en/latest/gbsa.html.
+
         solvent : :class:`str`, optional
             Solvent to use in GBSA implicit solvation method.
             For details see
@@ -266,10 +274,14 @@ class XTB(Optimizer):
                     'No solvent valid for version',
                     f' {gfn_version!r}.'
                 )
-            if not is_valid_xtb_solvent(gfn_version, solvent):
+            if not is_valid_xtb_solvent(
+                gfn_version=gfn_version,
+                solvent_model=solvent_model,
+                solvent=solvent,
+            ):
                 raise XTBInvalidSolventError(
-                    f'Solvent {solvent!r} is invalid for ',
-                    f'version {gfn_version!r}.'
+                    f'Solvent {solvent!r} and model {solvent_model!r}',
+                    f' is invalid for version {gfn_version!r}.'
                 )
 
         if not calculate_hessian and max_runs != 1:
@@ -290,6 +302,7 @@ class XTB(Optimizer):
         self._num_cores = str(num_cores)
         self._electronic_temperature = str(electronic_temperature)
         self._solvent = solvent
+        self._solvent_model = solvent_model
         self._solvent_grid = solvent_grid
         self._charge = str(charge)
         self._num_unpaired_electrons = str(num_unpaired_electrons)
@@ -391,9 +404,7 @@ class XTB(Optimizer):
             optimization = f'--opt {self._opt_level}'
 
         if self._solvent is not None:
-            solvent = (
-                f'--gbsa {self._solvent} bar1M {self._solvent_grid}'
-            )
+            solvent = f'--{self._solvent_model} {self._solvent} '
         else:
             solvent = ''
 
@@ -403,7 +414,7 @@ class XTB(Optimizer):
             f'{optimization} --parallel {self._num_cores} '
             f'--etemp {self._electronic_temperature} '
             f'{solvent} --chrg {self._charge} '
-            f'--uhf {self._num_unpaired_electrons}'
+            f'--uhf {self._num_unpaired_electrons} -I det_control.in'
         )
 
         with open(out_file, 'w') as f:
@@ -417,6 +428,12 @@ class XTB(Optimizer):
                 # Shell is required to run complex arguments.
                 shell=True
             )
+
+    def _write_detailed_control(self):
+        string = f'$gbsa\n   gbsagrid={self._solvent_grid}'
+
+        with open('det_control.in', 'w') as f:
+            f.write(string)
 
     def _run_optimizations(self, mol):
         """
@@ -442,6 +459,7 @@ class XTB(Optimizer):
             xyz = f'input_structure_{run+1}.xyz'
             out_file = f'optimization_{run+1}.output'
             mol.write(xyz)
+            self._write_detailed_control()
             self._run_xtb(xyz=xyz, out_file=out_file)
             # Check if the optimization is complete.
             coord_file = 'xtbhess.coord'
@@ -617,6 +635,7 @@ class XTBCREST(Optimizer):
         cross=True,
         charge=0,
         electronic_temperature=300,
+        solvent_model='gbsa',
         solvent=None,
         num_unpaired_electrons=0,
         unlimited_memory=False,
@@ -688,6 +707,13 @@ class XTBCREST(Optimizer):
         electronic_temperature : :class:`int`, optional
             Electronic temperature in Kelvin.
 
+        solvent_model : :class:`str`
+            Solvent model to use out of older `gbsa` and newer `alpb`.
+            `gbsa` is default for backwards compatability, but `alpb`
+            is recommended.
+            For details see
+            https://xtb-docs.readthedocs.io/en/latest/gbsa.html.
+
         solvent : :class:`str`, optional
             Solvent to use in GBSA implicit solvation method.
             For details see
@@ -714,10 +740,14 @@ class XTBCREST(Optimizer):
                     'No solvent valid for version',
                     f' {gfn_version!r}.'
                 )
-            if not is_valid_xtb_solvent(gfn_version, solvent):
+            if not is_valid_xtb_solvent(
+                gfn_version=gfn_version,
+                solvent_model=solvent_model,
+                solvent=solvent,
+            ):
                 raise XTBInvalidSolventError(
-                    f'Solvent {solvent!r} is invalid for ',
-                    f'version {gfn_version!r}.'
+                    f'Solvent {solvent!r} and model {solvent_model!r}',
+                    f' is invalid for version {gfn_version!r}.'
                 )
 
         self._crest_path = crest_path
@@ -738,6 +768,7 @@ class XTBCREST(Optimizer):
         self._keepdir = keepdir
         self._num_cores = str(num_cores)
         self._electronic_temperature = str(electronic_temperature)
+        self._solvent_model = solvent_model
         self._solvent = solvent
         self._charge = str(charge)
         self._num_unpaired_electrons = str(num_unpaired_electrons)
@@ -809,7 +840,7 @@ class XTBCREST(Optimizer):
             memory = ''
 
         if self._solvent is not None:
-            solvent = f'-g {self._solvent}'
+            solvent = f'--{self._solvent_model} {self._solvent}'
         else:
             solvent = ''
 

--- a/stko/utilities/utilities.py
+++ b/stko/utilities/utilities.py
@@ -391,7 +391,7 @@ class XTBInvalidSolventError(Exception):
     ...
 
 
-def is_valid_xtb_solvent(gfn_version, solvent):
+def is_valid_xtb_solvent(gfn_version, solvent_model, solvent):
     """
     Check if solvent is valid for the given GFN version.
 
@@ -399,6 +399,9 @@ def is_valid_xtb_solvent(gfn_version, solvent):
     ----------
     gfn_version : :class:`int`
         GFN parameterization version. Can be: ``0``, ``1`` or ``2``.
+
+    solvent_model : class:`str`
+        Solvent model being used [1]_.
 
     solvent : :class:`str`
         Solvent being tested [1]_.
@@ -413,24 +416,45 @@ def is_valid_xtb_solvent(gfn_version, solvent):
     .. [1] https://xtb-docs.readthedocs.io/en/latest/gbsa.html
 
     """
+
     if gfn_version == 0:
         return False
-    elif gfn_version == 1:
+    elif gfn_version == 1 and solvent_model == 'gbsa':
         valid_solvents = {
             'acetone', 'acetonitrile', 'benzene',
             'CH2Cl2'.lower(), 'CHCl3'.lower(), 'CS2'.lower(),
             'DMSO'.lower(), 'ether', 'H2O'.lower(),
-            'methanol', 'THF'.lower(), 'toluene'
+            'methanol', 'THF'.lower(), 'toluene', 'water',
         }
-        return solvent in valid_solvents
-    elif gfn_version == 2:
+    elif gfn_version == 1 and solvent_model == 'alpb':
         valid_solvents = {
-            'acetone', 'acetonitrile', 'CH2Cl2'.lower(),
-            'CHCl3'.lower(), 'CS2'.lower(), 'DMF'.lower(),
-            'DMSO'.lower(), 'ether', 'H2O'.lower(), 'methanol',
-            'n-hexane'.lower(), 'THF'.lower(), 'toluene'
+            'acetone', 'acetonitrile', 'aniline', 'benzaldehyde',
+            'benzene', 'CH2Cl2'.lower(), 'CHCl3'.lower(),
+            'CS2'.lower(), 'dioxane', 'DMF'.lower(), 'DMSO'.lower(),
+            'ether', 'ethylacetate', 'furane',
+            'hexandecane', 'hexane', 'H2O'.lower(), 'nitromethane',
+            'octanol', 'octanol (wet)', 'phenol', 'THF'.lower(),
+            'toluene', 'water',
         }
-        return solvent in valid_solvents
+    elif gfn_version == 2 and solvent_model == 'gbsa':
+        valid_solvents = {
+            'acetone', 'acetonitrile',
+            'benzene', 'CH2Cl2'.lower(), 'CHCl3'.lower(),
+            'CS2'.lower(), 'DMSO'.lower(),
+            'ether', 'hexane', 'methanol', 'H2O'.lower(),
+            'THF'.lower(), 'toluene', 'water',
+        }
+    elif gfn_version == 2 and solvent_model == 'alpb':
+        valid_solvents = {
+            'acetone', 'acetonitrile', 'aniline', 'benzaldehyde',
+            'benzene', 'CH2Cl2'.lower(), 'CHCl3'.lower(),
+            'CS2'.lower(), 'dioxane', 'DMF'.lower(), 'DMSO'.lower(),
+            'ether', 'ethylacetate', 'furane',
+            'hexandecane', 'hexane', 'H2O'.lower(), 'nitromethane',
+            'octanol', 'octanol (wet)', 'phenol', 'THF'.lower(),
+            'toluene', 'water',
+        }
+    return solvent in valid_solvents
 
 
 class XTBExtractor:


### PR DESCRIPTION
Updates command line to allow for solvent model (GBSA vs. new ALPB methods). Maintains backwards compatibility where GBSA is default. Introduces detailed input folder for GBSA grid setting.