### PR TITLE
Update docs for restricted optimisations

### DIFF
--- a/stko/optimizers/macromodel.py
+++ b/stko/optimizers/macromodel.py
@@ -550,10 +550,10 @@ class MacroModelForceField(MacroModel):
     Optimisation of `long bonds` only within
     :class:`stk.ConstructedMolecule` is possible with
     `restricted=True`.
-    Generally, this means bonds created during the construction process
-    will be fixed.
-    If the molecule is not a `ConstructedMolecule`, no positions will be
-    optimized.
+    Generally, this means any bonds created during the construction
+    process will be fixed.
+    If the molecule is not a `ConstructedMolecule`, no positions will
+    be optimized.
 
     .. code-block:: python
 
@@ -605,8 +605,10 @@ class MacroModelForceField(MacroModel):
 
         restricted : :class:`bool`, optional
             If ``True`` then an optimization is performed only on bonds
-            not associated with building block IDs. These bonds may not
-            correspond to the bonds formed between bonder atoms.
+            not associated with building block IDs. These bonds are
+            created during construction of the `.ConstructedMolecule`,
+            so will not correspond to the bonds formed between bonder
+            atoms.
             If ``False`` then all bonds are optimized.
 
         timeout : :class:`float`, optional

--- a/stko/optimizers/macromodel.py
+++ b/stko/optimizers/macromodel.py
@@ -550,8 +550,9 @@ class MacroModelForceField(MacroModel):
     Optimisation of `long bonds` only within
     :class:`stk.ConstructedMolecule` is possible with
     `restricted=True`.
-    Generally, this means any bonds created during the construction
-    process will be fixed.
+    Generally, this means only bonds created during the construction
+    process will be optimized,
+    and those belonging to building blocks will be fixed.
     If the molecule is not a `ConstructedMolecule`, no positions will
     be optimized.
 
@@ -605,10 +606,9 @@ class MacroModelForceField(MacroModel):
 
         restricted : :class:`bool`, optional
             If ``True`` then an optimization is performed only on bonds
-            not associated with building block IDs. These bonds are
-            created during construction of the `.ConstructedMolecule`,
-            so will not correspond to the bonds formed between bonder
-            atoms.
+            created during the `.ConstructedMolecule`
+            creation.
+            All building block bonds will be fixed.
             If ``False`` then all bonds are optimized.
 
         timeout : :class:`float`, optional

--- a/stko/optimizers/macromodel.py
+++ b/stko/optimizers/macromodel.py
@@ -606,7 +606,7 @@ class MacroModelForceField(MacroModel):
 
         restricted : :class:`bool`, optional
             If ``True`` then an optimization is performed only on bonds
-            created during the `.ConstructedMolecule`
+            created during the `ConstructedMolecule`
             creation.
             All building block bonds will be fixed.
             If ``False`` then all bonds are optimized.

--- a/stko/optimizers/macromodel.py
+++ b/stko/optimizers/macromodel.py
@@ -549,8 +549,10 @@ class MacroModelForceField(MacroModel):
 
     Optimisation of `long bonds` only within
     :class:`stk.ConstructedMolecule` is possible with
-    `restricted=True`. This fixes all other bonds. Therefore, if the
-    molecule is not a `ConstructedMolecule`, no positions will be
+    `restricted=True`.
+    Generally, this means bonds created during the construction process
+    will be fixed.
+    If the molecule is not a `ConstructedMolecule`, no positions will be
     optimized.
 
     .. code-block:: python


### PR DESCRIPTION
The purpose of this PR is to update the docs to be more clear about restricted and unrestricted optimisations which use the `MacroModelForceField` optimiser.
This PR closes #99 