### PR TITLE
Update tests and code to allow optional dependancies.

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -32,11 +32,11 @@ Make sure you also install rdkit, which is a dependency::
 
     $ conda install -c conda-forge rdkit
 
-Make sure you also install openbabel, which is a dependency::
+You can also install openbabel, which is an optional dependency::
 
     $ conda install -c conda-forge openbabel
 
-Make sure you also install MDAnalysis, which is a dependency::
+You can also install MDAnalysis, which is an optional dependency::
 
     $ pip install MDAnalysis
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setuptools.setup(
         'scipy',
         'numpy',
         'networkx',
-        'mdanalysis',
         'stk',
     ),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="stko",
-    version="0.0.39",
+    version="0.0.40",
     author="Steven Bennett, Andrew Tarzia",
     author_email="s.bennett18@imperial.ac.uk",
     description=(

--- a/stko/calculators/open_babel_calculators.py
+++ b/stko/calculators/open_babel_calculators.py
@@ -23,6 +23,14 @@ from ..utilities import WrapperNotInstalledException
 logger = logging.getLogger(__name__)
 
 
+class OpenBabelError(Exception):
+    ...
+
+
+class ForceFieldSetupError(OpenBabelError):
+    ...
+
+
 class OpenBabelEnergy(Calculator):
     """
     Uses OpenBabel to calculate forcefield energies.[1]_
@@ -87,7 +95,11 @@ class OpenBabelEnergy(Calculator):
         forcefield = openbabel.OBForceField.FindForceField(
             self._forcefield
         )
-        forcefield.Setup(OBMol)
+        outcome = forcefield.Setup(OBMol)
+        if not outcome:
+            raise ForceFieldSetupError(
+                f"{self._forcefield} could not be setup for {mol}"
+            )
 
         yield forcefield.Energy()
 

--- a/stko/molecular/conversion/md_analysis.py
+++ b/stko/molecular/conversion/md_analysis.py
@@ -10,7 +10,12 @@ Class for converting a molecule to and back from an MDAnalysis object.
 
 import logging
 
-import MDAnalysis as mda
+from ...utilities import WrapperNotInstalledException
+
+try:
+    import MDAnalysis as mda
+except ModuleNotFoundError:
+    mda = None
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +45,13 @@ class MDAnalysis:
         print('stk centroid:', stkmol.get_centroid())
 
     """
+
+    def __init__(self):
+        if mda is None:
+            raise WrapperNotInstalledException(
+                'MDAnalysis is not installed; see README for '
+                'installation.'
+            )
 
     def get_universe(self, mol):
         """

--- a/stko/utilities/utilities.py
+++ b/stko/utilities/utilities.py
@@ -20,6 +20,10 @@ from itertools import chain
 from scipy.spatial.distance import euclidean
 
 
+class WrapperNotInstalledException(Exception):
+    ...
+
+
 # This dictionary gives easy access to the rdkit bond types.
 bond_dict = {'1': rdkit.rdchem.BondType.SINGLE,
              'am': rdkit.rdchem.BondType.SINGLE,

--- a/tests/calculators/test_obabel_calculators.py
+++ b/tests/calculators/test_obabel_calculators.py
@@ -1,19 +1,31 @@
 import stko
+import pytest
+
+try:
+    from openbabel import openbabel
+except ImportError:
+    openbabel = None
 
 
 def test_open_babel_energy(unoptimized_mol):
-    calculator = stko.OpenBabelEnergy('uff')
-    test_energy = calculator.get_energy(unoptimized_mol)
-    assert test_energy == 141.44622279628743
 
-    calculator = stko.OpenBabelEnergy('gaff')
-    test_energy = calculator.get_energy(unoptimized_mol)
-    assert test_energy == 66.47095418890525
+    if openbabel is None:
+        with pytest.raises(stko.WrapperNotInstalledException) as e:
+            calculator = stko.OpenBabelEnergy('uff')
+    else:
 
-    calculator = stko.OpenBabelEnergy('ghemical')
-    test_energy = calculator.get_energy(unoptimized_mol)
-    assert test_energy == 86.59956589041794
+        calculator = stko.OpenBabelEnergy('uff')
+        test_energy = calculator.get_energy(unoptimized_mol)
+        assert test_energy == 141.44622279628743
 
-    calculator = stko.OpenBabelEnergy('mmff94')
-    test_energy = calculator.get_energy(unoptimized_mol)
-    assert test_energy == 7.607999187460175
+        calculator = stko.OpenBabelEnergy('gaff')
+        test_energy = calculator.get_energy(unoptimized_mol)
+        assert test_energy == 66.47095418890525
+
+        calculator = stko.OpenBabelEnergy('ghemical')
+        test_energy = calculator.get_energy(unoptimized_mol)
+        assert test_energy == 86.59956589041794
+
+        calculator = stko.OpenBabelEnergy('mmff94')
+        test_energy = calculator.get_energy(unoptimized_mol)
+        assert test_energy == 7.607999187460175

--- a/tests/calculators/test_obabel_calculators.py
+++ b/tests/calculators/test_obabel_calculators.py
@@ -10,7 +10,7 @@ except ImportError:
 def test_open_babel_energy(unoptimized_mol):
 
     if openbabel is None:
-        with pytest.raises(stko.WrapperNotInstalledException) as e:
+        with pytest.raises(stko.WrapperNotInstalledException):
             calculator = stko.OpenBabelEnergy('uff')
     else:
 

--- a/tests/molecular/mdanalysis/test_universe.py
+++ b/tests/molecular/mdanalysis/test_universe.py
@@ -1,5 +1,11 @@
 import stko
 import numpy as np
+import pytest
+
+try:
+    import MDAnalysis as mda
+except ModuleNotFoundError:
+    mda = None
 
 
 def test_universe(molecule):
@@ -17,14 +23,18 @@ def test_universe(molecule):
 
     """
 
-    result = stko.MDAnalysis().get_universe(molecule)
+    if mda is None:
+        with pytest.raises(stko.WrapperNotInstalledException) as e:
+            result = stko.MDAnalysis().get_universe(molecule)
+    else:
+        result = stko.MDAnalysis().get_universe(molecule)
 
-    assert result.atoms.n_atoms == molecule.get_num_atoms()
+        assert result.atoms.n_atoms == molecule.get_num_atoms()
 
-    for atom, stk_atom in zip(result.atoms, molecule.get_atoms()):
-        assert atom.ix == stk_atom.get_id()
+        for atom, stk_atom in zip(result.atoms, molecule.get_atoms()):
+            assert atom.ix == stk_atom.get_id()
 
-    for pos, stk_pos in zip(
-        result.atoms.positions, molecule.get_position_matrix()
-    ):
-        assert np.allclose(pos, stk_pos)
+        for pos, stk_pos in zip(
+            result.atoms.positions, molecule.get_position_matrix()
+        ):
+            assert np.allclose(pos, stk_pos)

--- a/tests/molecular/mdanalysis/test_universe.py
+++ b/tests/molecular/mdanalysis/test_universe.py
@@ -24,7 +24,7 @@ def test_universe(molecule):
     """
 
     if mda is None:
-        with pytest.raises(stko.WrapperNotInstalledException) as e:
+        with pytest.raises(stko.WrapperNotInstalledException):
             result = stko.MDAnalysis().get_universe(molecule)
     else:
         result = stko.MDAnalysis().get_universe(molecule)

--- a/tests/optimizers/openbabel/test_obabel_optimizers.py
+++ b/tests/optimizers/openbabel/test_obabel_optimizers.py
@@ -16,7 +16,7 @@ except ImportError:
 def test_open_babel(case_molecule):
 
     if openbabel is None:
-        with pytest.raises(stko.WrapperNotInstalledException) as e:
+        with pytest.raises(stko.WrapperNotInstalledException):
             energy = (
                 stko.OpenBabelEnergy('uff').get_energy(
                     mol=case_molecule.molecule,

--- a/tests/optimizers/openbabel/test_obabel_optimizers.py
+++ b/tests/optimizers/openbabel/test_obabel_optimizers.py
@@ -1,23 +1,41 @@
 import stko
+import pytest
+
 from ..utilities import (
     inequivalent_position_matrices,
     is_equivalent_molecule,
 )
 import numpy as np
 
+try:
+    from openbabel import openbabel
+except ImportError:
+    openbabel = None
+
 
 def test_open_babel(case_molecule):
-    energy = (
-        stko.OpenBabelEnergy('uff').get_energy(case_molecule.molecule)
-    )
-    optimizer = stko.OpenBabel('uff')
-    opt_res = optimizer.optimize(case_molecule.molecule)
-    is_equivalent_molecule(opt_res, case_molecule.molecule)
-    inequivalent_position_matrices(opt_res, case_molecule.molecule)
-    opt_energy = (
-        stko.OpenBabelEnergy('uff').get_energy(opt_res)
-    )
-    assert np.isclose(
-        energy, case_molecule.unoptimised_energy, atol=1E-3
-    )
-    assert opt_energy < case_molecule.unoptimised_energy
+
+    if openbabel is None:
+        with pytest.raises(stko.WrapperNotInstalledException) as e:
+            energy = (
+                stko.OpenBabelEnergy('uff').get_energy(
+                    mol=case_molecule.molecule,
+                )
+            )
+    else:
+        energy = (
+            stko.OpenBabelEnergy('uff').get_energy(
+                mol=case_molecule.molecule,
+            )
+        )
+        optimizer = stko.OpenBabel('uff')
+        opt_res = optimizer.optimize(case_molecule.molecule)
+        is_equivalent_molecule(opt_res, case_molecule.molecule)
+        inequivalent_position_matrices(opt_res, case_molecule.molecule)
+        opt_energy = (
+            stko.OpenBabelEnergy('uff').get_energy(opt_res)
+        )
+        assert np.isclose(
+            energy, case_molecule.unoptimised_energy, atol=1E-3
+        )
+        assert opt_energy < case_molecule.unoptimised_energy


### PR DESCRIPTION
@stevenkbennett solves your issue from today with openbabel and mdanalysis. 

Rdkit remains because it is required by stk.