### PR TITLE
Update minimum version of Python to 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.9',
 )


### PR DESCRIPTION
This should match the minimum version required by one of the
dependencies `stk`, allowing users to keep using up-to-date
software.