### PR TITLE
Update dependencies

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -24,21 +24,13 @@ To get ``stko``, you can install it with pip::
 
     $ pip install stko
 
-Make sure you also install stk, which is a dependency::
-
-    $ pip install stk
-
-Make sure you also install rdkit, which is a dependency::
-
-    $ conda install -c conda-forge rdkit
-
 You can also install openbabel, which is an optional dependency::
 
     $ conda install -c conda-forge openbabel
 
 You can also install MDAnalysis, which is an optional dependency::
 
-    $ pip install MDAnalysis
+    $ conda install -c mdanalysis
 
 Examples
 ========

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
         'numpy',
         'networkx',
         'stk',
+        'rdkit-pypi',
     ),
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -1,77 +1,97 @@
-name: stko_tests
 channels:
   - conda-forge
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=1_gnu
-  - boost=1.74.0=py39h5472131_3
-  - boost-cpp=1.74.0=h312852a_4
+  - _openmp_mutex=4.5=2_gnu
+  - biopython=1.79=py39h3811e60_1
   - bzip2=1.0.8=h7f98852_4
+  - c-ares=1.18.1=h7f98852_0
   - ca-certificates=2021.10.8=ha878542_0
-  - cairo=1.16.0=h6cf1ce9_1008
-  - certifi=2021.10.8=py39hf3d152e_1
-  - cycler=0.10.0=py_2
-  - fontconfig=2.13.1=hba837de_1005
+  - cairo=1.16.0=h18b612c_1001
+  - certifi=2021.10.8=py39hf3d152e_2
+  - cftime=1.6.0=py39hd257fcd_1
+  - colorama=0.4.4=pyh9f0ad1d_0
+  - curl=7.82.0=h7f8727e_0
+  - cycler=0.11.0=pyhd8ed1ab_0
+  - expat=2.4.8=h27087fc_0
+  - fontconfig=2.14.0=h8e229c2_0
   - freetype=2.10.4=h0708190_1
-  - gettext=0.19.8.1=h0b5b191_1005
-  - greenlet=1.1.1=py39he80948d_0
-  - icu=68.1=h58526e2_0
-  - jbig=2.1=h7f98852_2003
-  - jpeg=9d=h36c2ea0_0
-  - kiwisolver=1.3.1=py39h1a9c180_1
+  - glib=2.69.1=h4ff587b_1
+  - griddataformats=0.7.0=pyhd8ed1ab_0
+  - gsd=2.5.2=py39hd257fcd_0
+  - hdf4=4.2.15=h10796ff_3
+  - hdf5=1.12.1=nompi_h2750804_100
+  - icu=58.2=hf484d3e_1000
+  - joblib=1.1.0=pyhd8ed1ab_0
+  - jpeg=9e=h166bdaf_1
+  - keyutils=1.6.1=h166bdaf_0
+  - kiwisolver=1.4.2=py39hf939315_1
+  - krb5=1.19.3=h3790be6_0
   - lcms2=2.12=hddcbb42_0
-  - ld_impl_linux-64=2.36.1=hea4e1c9_2
-  - lerc=2.2.1=h9c3ff4c_0
-  - libblas=3.9.0=11_linux64_openblas
-  - libcblas=3.9.0=11_linux64_openblas
-  - libdeflate=1.7=h7f98852_5
-  - libffi=3.3=h58526e2_2
-  - libgcc-ng=11.1.0=hc902ee8_8
-  - libgfortran-ng=11.1.0=h69a702a_8
-  - libgfortran5=11.1.0=h6c583b3_8
-  - libglib=2.68.4=h3e27bee_0
-  - libgomp=11.1.0=hc902ee8_8
-  - libiconv=1.16=h516909a_0
-  - liblapack=3.9.0=11_linux64_openblas
-  - libopenblas=0.3.17=pthreads_h8fe5266_1
+  - ld_impl_linux-64=2.35.1=h7274673_9
+  - libblas=3.9.0=14_linux64_openblas
+  - libcblas=3.9.0=14_linux64_openblas
+  - libcurl=7.82.0=h0b77cf5_0
+  - libedit=3.1.20191231=he28a2e2_2
+  - libev=4.33=h516909a_1
+  - libffi=3.3=he6710b0_2
+  - libgcc-ng=11.2.0=h1d223b6_16
+  - libgfortran-ng=11.2.0=h69a702a_16
+  - libgfortran5=11.2.0=h5c6108e_16
+  - libgomp=11.2.0=h1d223b6_16
+  - liblapack=3.9.0=14_linux64_openblas
+  - libnetcdf=4.8.1=nompi_hb3fd0d9_101
+  - libnghttp2=1.46.0=hce63b2e_0
+  - libopenblas=0.3.20=pthreads_h78a6416_0
   - libpng=1.6.37=h21135ba_2
-  - libstdcxx-ng=11.1.0=h56837e0_8
-  - libtiff=4.3.0=hf544144_1
+  - libssh2=1.10.0=ha56f1ee_2
+  - libstdcxx-ng=11.2.0=he4da1e4_16
+  - libtiff=4.2.0=h85742a9_0
   - libuuid=2.32.1=h7f98852_1000
-  - libwebp-base=1.2.1=h7f98852_0
-  - libxcb=1.13=h7f98852_1003
-  - libxml2=2.9.12=h72842e0_0
+  - libwebp-base=1.2.2=h7f98852_1
+  - libxcb=1.13=h7f98852_1004
+  - libxml2=2.9.12=h74e7548_1
+  - libzip=1.8.0=h4de3113_1
   - lz4-c=1.9.3=h9c3ff4c_1
-  - matplotlib-base=3.4.3=py39h2fa2bec_0
-  - ncurses=6.2=h58526e2_4
-  - numpy=1.21.2=py39hdbf815f_0
+  - matplotlib-base=3.4.3=py39h2fa2bec_2
+  - mdanalysis=2.1.0=py39h5a03fae_2
+  - mmtf-python=1.1.2=py_0
+  - mrcfile=1.3.0=pyh44b312d_0
+  - msgpack-python=1.0.3=py39hf939315_1
+  - ncurses=6.3=h7f8727e_2
+  - netcdf4=1.5.8=nompi_py39h64b754b_101
+  - networkx=2.8=pyhd8ed1ab_0
+  - numpy=1.22.3=py39hc58783e_2
   - olefile=0.46=pyh9f0ad1d_1
   - openbabel=3.1.1=py39hee2736e_2
-  - openjpeg=2.4.0=hb52868f_1
-  - openssl=1.1.1l=h7f98852_0
+  - openssl=1.1.1o=h166bdaf_0
+  - packaging=21.3=pyhd8ed1ab_0
+  - patsy=0.5.2=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
-  - pillow=8.3.1=py39ha612740_0
-  - pip=21.2.4=pyhd8ed1ab_0
-  - pixman=0.40.0=h36c2ea0_0
+  - pip=21.2.4=py39h06a4308_0
+  - pixman=0.38.0=h516909a_1003
   - pthread-stubs=0.4=h36c2ea0_1001
-  - pycairo=1.20.1=py39hedcb9fc_0
-  - pyparsing=2.4.7=pyh9f0ad1d_0
-  - python=3.9.6=h49503c6_1_cpython
+  - pyparsing=3.0.8=pyhd8ed1ab_0
+  - python=3.9.12=h12debd9_0
   - python-dateutil=2.8.2=pyhd8ed1ab_0
   - python_abi=3.9=2_cp39
-  - pytz=2021.1=pyhd8ed1ab_0
-  - rdkit=2021.03.4=py39hccf6a74_0
-  - readline=8.1=h46c0cb4_0
-  - reportlab=3.5.68=py39he59360d_0
-  - setuptools=57.4.0=py39hf3d152e_0
+  - pytz=2022.1=pyhd8ed1ab_0
+  - readline=8.1.2=h7f8727e_1
+  - scikit-learn=1.0.2=py39h4dfa638_0
+  - scipy=1.8.0=py39hee8e79c_1
+  - seaborn=0.11.2=hd8ed1ab_0
+  - seaborn-base=0.11.2=pyhd8ed1ab_0
+  - setuptools=61.2.0=py39h06a4308_0
   - six=1.16.0=pyh6c4a22f_0
-  - sqlalchemy=1.4.23=py39h3811e60_0
-  - sqlite=3.36.0=h9cd32fc_0
-  - tk=8.6.10=h21135ba_1
-  - tornado=6.1=py39h3811e60_1
-  - tzdata=2021a=he74cb21_1
-  - wheel=0.37.0=pyhd8ed1ab_1
+  - sqlite=3.38.3=hc218d9a_0
+  - statsmodels=0.13.2=py39hce5d2b2_0
+  - threadpoolctl=3.1.0=pyh8a188c0_0
+  - tk=8.6.11=h1ccaba5_0
+  - tornado=6.1=py39hb9d737c_3
+  - tqdm=4.64.0=pyhd8ed1ab_0
+  - tzdata=2022a=hda174b7_0
+  - wheel=0.37.1=pyhd3eb1b0_0
   - xorg-kbproto=1.0.7=h7f98852_1002
   - xorg-libice=1.0.10=h7f98852_0
   - xorg-libsm=1.2.3=hd9c2040_1000
@@ -83,40 +103,30 @@ dependencies:
   - xorg-renderproto=0.11.1=h7f98852_1002
   - xorg-xextproto=7.3.0=h7f98852_1002
   - xorg-xproto=7.0.31=h7f98852_1007
-  - xz=5.2.5=h516909a_1
-  - zlib=1.2.11=h516909a_1010
-  - zstd=1.5.0=ha95c52a_0
+  - xz=5.2.5=h7f8727e_1
+  - zlib=1.2.12=h7f8727e_2
+  - zstd=1.4.9=ha95c52a_0
   - pip:
-    - attrs==21.2.0
-    - biopython==1.79
+    - attrs==21.4.0
     - dill==0.3.4
-    - dnspython==1.16.0
-    - griddataformats==0.5.0
-    - gsd==2.4.2
+    - dnspython==2.2.1
+    - fonttools==4.33.3
     - iniconfig==1.1.1
-    - joblib==1.0.1
+    - matplotlib==3.5.2
     - mchammer==1.0.4
-    - mdanalysis==2.0.0
-    - mmtf-python==1.1.2
-    - msgpack==1.0.2
     - multiprocess==0.70.12.2
-    - networkx==2.6.2
-    - packaging==21.0
-    - pandas==1.3.2
+    - pandas==1.4.2
     - pathos==0.2.8
-    - pluggy==0.13.1
+    - pillow==9.1.0
+    - pluggy==1.0.0
     - pox==0.3.0
     - ppft==1.6.6.4
-    - py==1.10.0
-    - pymongo==3.12.0
-    - pytest==6.2.4
+    - py==1.11.0
+    - pymongo==4.1.1
+    - pytest==7.1.2
     - pytest-lazy-fixture==0.6.3
-    - scipy==1.7.1
-    - seaborn==0.11.2
-    - spindry==0.0.9
-    - stk==2021.8.2.0
-    - threadpoolctl==2.2.0
-    - toml==0.10.2
-    - tqdm==4.62.2
+    - rdkit-pypi==2022.3.2.1
+    - spindry==0.0.91
+    - stk==2022.5.2.1
+    - tomli==2.0.1
     - vabene==0.0.5
-prefix: /home/atarzia/anaconda3/envs/stko_tests

--- a/tests/optimizers/aligner/test_aligner.py
+++ b/tests/optimizers/aligner/test_aligner.py
@@ -37,6 +37,10 @@ def test_alignment_potential(case_potential):
         width=2,
     )
     supramolecule = aligner._get_supramolecule(case_potential.molecule)
-    assert case_potential.potential == potential.compute_potential(
-        supramolecule,
+    assert np.isclose(
+        case_potential.potential,
+        potential.compute_potential(
+            supramolecule,
+        ),
+        atol=1E-6,
     )


### PR DESCRIPTION
Related Issues: #148 

Updated the dependencies in `test/environment.yml` as the minimum
python version has been bumped to 3.9 and `rdkit` is not being
installed through `pypi`. `mdanalysis` is also being installed through
`conda install -c conda-forga mdanalysis` rather than
`pip install mdanalysis` because the `pip` version seem lacking
dependencies and is causing crashing when `pytest` is run. This is
fixed by simply using the `conda` version of the package, presumably
because it installs the required binaries that are missing in the
`pip` version.

Also updated `readme.rst` to reflect that `mdanalysis` needs to be
installed from `conda` and that `stk` and `rdkit` do not need to be
installed explicitly, as they are requirements in `setup.py`.

Finally, removed the `prefix` and `name` keys from
`tests/environment.yml` as these can modify global environments on the
users computer. Instead the environmnent file should be used in an
active environment in the following way

```
conda env update --file tests/environment.yml
```

which will simply add the dependencies in `tests/environment.yml` to
the current active environment, instead of creating a new global
enivonrment, as was being done previously.

Also update the comparison of some floating point tests
to only check for an accuracy of `1E-6` as there appears to
be some non-determinism across machines and in GitHub's
CI.

Co-authored-by: Austin Mroz <austin.mroz@gmail.com>